### PR TITLE
[ssemver:minor] [OPS-324] Additional legacy support

### DIFF
--- a/src/commands/test.yml
+++ b/src/commands/test.yml
@@ -14,6 +14,10 @@ parameters:
     description: Additional flags to pass to Maven
     type: string
     default: -B -q
+  test-coverage-file:
+    description: File containing test coverage information
+    type: string
+    default: target/reports/jacoco.xml
   test-report-directory:
     description: Directory to find test reports
     type: string
@@ -61,7 +65,7 @@ steps:
               export JACOCO_SOURCE_PATH=src/main/java
 
               # Upload the coverage report
-              ./cc-test-reporter format-coverage -t jacoco target/reports/jacoco.xml -p github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/
+              ./cc-test-reporter format-coverage -t jacoco << parameters.test-coverage-file >> -p github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/
               ./cc-test-reporter upload-coverage
   - run:
       name: Copy over test coverage artifacts

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -22,6 +22,10 @@ parameters:
     description: Additional flags to pass to Maven
     type: string
     default: -B -q
+  test-coverage-file:
+    description: File containing test coverage information
+    type: string
+    default: target/reports/jacoco.xml
   test-report-directory:
     description: Directory to find test reports
     type: string
@@ -36,5 +40,6 @@ steps:
       artifact-directory: << parameters.artifact-directory >>
       maven-settings: << parameters.maven-settings >>
       maven-flags: << parameters.maven-flags >>
+      test-coverage-file:  <<  parameters.test-coverage-file >>
       test-report-directory:  <<  parameters.test-report-directory >>
       test-reporter-id: << parameters.test-reporter-id >>


### PR DESCRIPTION
* Allow specification of the test coverage file.  For legacy projects target/reports is not currently the best/default place for the JaCoCo output.