### PR TITLE
[OPS-324] Make workflow look up more robust

### DIFF
--- a/src/scripts/create_circle_build.sh
+++ b/src/scripts/create_circle_build.sh
@@ -38,6 +38,11 @@ for project in ${PROJECTS-}; do
 	case "${STATUS_CODE}" in
 		2*)
 			# If the build request was successful, look up the workflow that was created
+
+			# First sleep to allow CircleCI to reach consistency
+			sleep 5
+
+			# Now look up the workflow
 			WORKFLOW_NUMBER=$(jq -r ".number // \"\"" "${OUTPUT_FILE}")
 			PIPELINE_ID=$(jq -r ".id // \"\"" "${OUTPUT_FILE}")
 			WORKFLOW_ID=


### PR DESCRIPTION
* Sleep before attempting to look up the workflow.  It seems like CircleCI has some lag in either creating the workflow or reaching consistency in terms of looking it up.  This time period seems to lead to a successful look up in testing rather than transitory look up failures.