### PR TITLE
Handle absent build artifacts

### DIFF
--- a/src/commands/test.yml
+++ b/src/commands/test.yml
@@ -74,6 +74,10 @@ steps:
   - run:
       name: Copy over test coverage artifacts
       command: |
-        cp -r << parameters.test-report-directory >> << parameters.artifact-directory >>
+        if [ -d "<<parameters.test-report-directory>>" ]; then
+            cp -r << parameters.test-report-directory >> << parameters.artifact-directory >>
+        else
+            echo "Report directory <<parameters.test-report-directory>> not found"
+        fi
   - store_artifacts:
       path: << parameters.artifact-directory >>

--- a/src/commands/test.yml
+++ b/src/commands/test.yml
@@ -65,8 +65,12 @@ steps:
               export JACOCO_SOURCE_PATH=src/main/java
 
               # Upload the coverage report
-              ./cc-test-reporter format-coverage -t jacoco << parameters.test-coverage-file >> -p github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/
-              ./cc-test-reporter upload-coverage
+              if [ -f "<<parameters.test-coverage-file>>" ]; then
+                  ./cc-test-reporter format-coverage -t jacoco << parameters.test-coverage-file >> -p github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/
+                  ./cc-test-reporter upload-coverage
+              else
+                  echo "Coverage file <<parameters.test-coverage-file>> not found"
+              fi
   - run:
       name: Copy over test coverage artifacts
       command: |


### PR DESCRIPTION
* If the coverage file is absent (e.g. all tests are ignored) then warn about this rather than failing
* If the report directory is absent then warn about this rather than failing