### PR TITLE
[semver:minor] Change image namespace in executor

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -2,7 +2,7 @@ description: >
   Default executor for Java/Spring Boot projects
 
 docker:
-  - image: circleci/openjdk:<<parameters.version>>-jdk
+  - image: cimg/openjdk:<<parameters.version>>-jdk
 
 parameters:
   version:


### PR DESCRIPTION
I got a warning in an lasw-service deploy about using deprecated docker containers and it linked to here https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034

This should be correct format as far as I can tell but I have not tested it.