### PR TITLE
[semver:minor] [MY-5183] Maven verify

### DIFF
--- a/src/commands/verify.yml
+++ b/src/commands/verify.yml
@@ -1,0 +1,41 @@
+description: >
+  Run verify
+
+parameters:
+  artifact-directory:
+    description: Directory to place verification artifacts into
+    type: string
+    default: /tmp/artifacts
+  maven-settings:
+    description: Location of Maven settings file
+    type: string
+    default: .circleci/settings.xml
+  maven-flags:
+    description: Additional flags to pass to Maven
+    type: string
+    default: -B -q
+  report-directory:
+    description: Directory to find reports in
+    type: string
+    default: target/verify-reports
+
+steps:
+  - cache-dependencies
+  - run:
+      name: Create an artifact directory
+      command: |
+        mkdir -p << parameters.artifact-directory >>
+  - run:
+      name: Verify
+      command: |
+        mvn -s << parameters.maven-settings >> << parameters.maven-flags >> verify
+  - run:
+      name: Copy over verification artifacts
+      command: |
+        if [ -d "<<parameters.report-directory>>" ]; then
+            cp -r << parameters.report-directory >> << parameters.artifact-directory >>
+        else
+            echo "Report directory <<parameters.report-directory>> not found"
+        fi
+  - store_artifacts:
+      path: << parameters.artifact-directory >>

--- a/src/examples/maven-verify-job.yml
+++ b/src/examples/maven-verify-job.yml
@@ -1,0 +1,14 @@
+description: >
+  Example of a job that will run Maven's verify step
+
+usage:
+  version: 2.1
+
+  orbs:
+    java: achievementnetwork/java-orb@1.0.0
+
+  jobs:
+    maven-test:
+      executor: java/default
+      steps:
+        - java/verify

--- a/src/jobs/verify.yml
+++ b/src/jobs/verify.yml
@@ -1,0 +1,35 @@
+description: >
+  Run verify
+
+executor:
+  name: default
+  version: <<parameters.java-version>>
+
+parameters:
+  artifact-directory:
+    description: Directory to place verification artifacts into
+    type: string
+    default: /tmp/artifacts
+  java-version:
+    description: The version of Java to use
+    type: string
+    default: '11'
+  maven-settings:
+    description: Location of Maven settings file
+    type: string
+    default: .circleci/settings.xml
+  maven-flags:
+    description: Additional flags to pass to Maven
+    type: string
+    default: -B -q
+  report-directory:
+    description: Directory to find reports
+    type: string
+    default: target/verify-reports
+
+steps:
+  - verify:
+      artifact-directory: << parameters.artifact-directory >>
+      maven-settings: << parameters.maven-settings >>
+      maven-flags: << parameters.maven-flags >>
+      report-directory:  <<  parameters.report-directory >>


### PR DESCRIPTION
* Set up a command and job to allow Maven verify to be run by Java
  builds.  This will allow additional verification steps beyond
  tests (e.g. linting and other static analysis).