### PR TITLE
Make Maven output more detailed in CircleCI

### DIFF
--- a/src/commands/cache-dependencies.yml
+++ b/src/commands/cache-dependencies.yml
@@ -9,7 +9,7 @@ parameters:
   maven-flags:
     description: Additional flags to pass to Maven
     type: string
-    default: -B -q
+    default: -B
 
 steps:
   - checkout

--- a/src/commands/compile.yml
+++ b/src/commands/compile.yml
@@ -9,7 +9,7 @@ parameters:
   maven-flags:
     description: Additional flags to pass to Maven
     type: string
-    default: -B -q
+    default: -B
 
 steps:
   - cache-dependencies

--- a/src/commands/test.yml
+++ b/src/commands/test.yml
@@ -13,7 +13,7 @@ parameters:
   maven-flags:
     description: Additional flags to pass to Maven
     type: string
-    default: -B -q
+    default: -B
   test-coverage-file:
     description: File containing test coverage information
     type: string

--- a/src/commands/verify.yml
+++ b/src/commands/verify.yml
@@ -13,7 +13,7 @@ parameters:
   maven-flags:
     description: Additional flags to pass to Maven
     type: string
-    default: -B -q
+    default: -B
   report-directory:
     description: Directory to find reports in
     type: string

--- a/src/jobs/compile.yml
+++ b/src/jobs/compile.yml
@@ -17,7 +17,7 @@ parameters:
   maven-flags:
     description: Additional flags to pass to Maven
     type: string
-    default: -B -q
+    default: -B
 
 steps:
   - compile:

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -21,7 +21,7 @@ parameters:
   maven-flags:
     description: Additional flags to pass to Maven
     type: string
-    default: -B -q
+    default: -B
   test-coverage-file:
     description: File containing test coverage information
     type: string

--- a/src/jobs/verify.yml
+++ b/src/jobs/verify.yml
@@ -21,7 +21,7 @@ parameters:
   maven-flags:
     description: Additional flags to pass to Maven
     type: string
-    default: -B -q
+    default: -B
   report-directory:
     description: Directory to find reports
     type: string


### PR DESCRIPTION
* Up till now the default for our builds has been to use `-q` which suppresses a lot of Maven output except for when things go wrong.  That also means that a lot of context around the errors gets suppressed, as are warnings.  For me, that has meant there are two situations for our builds.

  1. The build failed.  It's often not obvious why, and I need  to override these flags to get the information I need to troubleshoot.
  2. The build succeeded, and I don't look at the build output.

  In the first case having the extra detail is helpful.  In the second case it makes no difference.

  Overall I think this means *not* passing `-q` is a more useful default.